### PR TITLE
Add support for Windows builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ build/tizen/m4/
 *.gcda
 build/tizen/.deps/
 build/tizen/.libs/
-
+build/tizen/build/

--- a/README.md
+++ b/README.md
@@ -57,3 +57,34 @@ Then run the following commands:
  ./configure --prefix=$DESKTOP_PREFIX
  make install -j8
 
+3. Building for Windows
+=======================
+
+Third party dependencies are built using vcpkg. Instructions on how to install vcpkg can be found in the
+vcpkg-script folder in the windows-dependencies repository.
+
+- Download the windows-dependencies repository from DaliHub
+
+         $ git clone https://github.com/dalihub/windows-dependencies.git
+
+- Read the windows-dependencies/vcpkg-script/Readme.md file for more instructions on how to build and install the third-party dependencies.
+
+3.1 Building with CMake
+-----------------------
+
+  * Requirements
+    It's required the version 3.12.2 of CMake and Visual Studio Community Edition
+
+  * Define an environment variable to set the path to the VCPKG folder
+
+    $ set VCPKG_FOLDER=C:/Users/username/Workspace/VCPKG_TOOL
+
+  * Define an environment variable to set the path where DALi is going to be installed.
+
+    $ set DALI_ENV_FOLDER=C:/Users/username/Workspace/dali-env
+
+  * Execute the following commands to create the makefiles, build and install DALi.
+
+    $ cmake -g Ninja . -DCMAKE_TOOLCHAIN_FILE=%VCPKG_FOLDER%/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_INSTALL_PREFIX=%DALI_ENV_FOLDER%
+
+    $ cmake --build . --target install

--- a/build/tizen/CMakeLists.txt
+++ b/build/tizen/CMakeLists.txt
@@ -1,0 +1,135 @@
+cmake_minimum_required(VERSION 3.1)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 99)
+
+set(name "dali2-csharp-binder")
+
+project(${name} CXX)
+
+set(${name}_VERSION_MAJOR 2)
+set(${name}_VERSION_MINOR 0)
+set(${name}_VERSION_PATCH 0)
+set(${name}_VERSION ${${name}_VERSION_MAJOR}.${${name}_VERSION_MINOR}.${${name}_VERSION_PATCH})
+
+add_definitions(-DDALI_PROFILE_WINDOWS)
+add_compile_options( /FIdali-windows-dependencies.h ) # Adds missing definitions.
+add_compile_options( /vmg ) # Avoids a 'reinterpret_cast' compile error while compiling signals and callbacks.
+add_compile_options( /wd4251 ) # Ignores warning C4251: "'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'"
+
+add_definitions(-D_USE_MATH_DEFINES)
+
+set(VCPKG_INCLUDE_DIR "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
+
+find_package( pthreads REQUIRED )
+find_package( curl REQUIRED )
+find_library( GETOPT_LIBRARY NAMES getopt )
+find_library( EXIF_LIBRARY NAMES libexif )
+
+find_package( png REQUIRED )
+find_package( gif REQUIRED )
+find_package( jpeg REQUIRED )
+find_library( TURBO_JPEG_LIBRARY NAMES turbojpeg )
+
+find_package( unofficial-fontconfig REQUIRED )
+find_package( freetype REQUIRED )
+find_package( harfbuzz REQUIRED )
+find_library( FRIBIDI_LIBRARY NAMES fribidi )
+
+find_package( unofficial-angle REQUIRED )
+find_package( unofficial-cairo REQUIRED )
+
+find_package( WebP REQUIRED )
+
+find_package( dali-windows-dependencies REQUIRED )
+find_package( dali2-core REQUIRED )
+find_package( dali2-adaptor REQUIRED )
+find_package( dali2-toolkit REQUIRED )
+
+# Set up the include dir
+set( INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include )
+set( LIB_DIR ${CMAKE_INSTALL_PREFIX}/lib )
+set( BIN_DIR ${CMAKE_INSTALL_PREFIX}/bin )
+
+set( REQUIRED_LIBS
+  PThreads4W::PThreads4W
+  CURL::libcurl
+  ${GETOPT_LIBRARY}
+  ${EXIF_LIBRARY}
+  ${PNG_LIBRARIES}
+  ${GIF_LIBRARIES}
+  JPEG::JPEG
+  ${TURBO_JPEG_LIBRARY}
+  unofficial::fontconfig::fontconfig
+  Freetype::Freetype
+  harfbuzz::harfbuzz
+  ${FRIBIDI_LIBRARY}
+  unofficial::angle::libEGL
+  unofficial::angle::libGLESv2
+  unofficial::cairo::cairo
+  WebP::webp
+  WebP::webpdemux
+  dali-windows-dependencies::dali-windows-dependencies
+  dali2-core::dali2-core
+  dali2-adaptor::dali2-adaptor
+  dali2-toolkit::dali2-toolkit
+)
+
+include_directories(
+  ${VCPKG_INCLUDE_DIR}
+  ${CMAKE_INSTALL_PREFIX}/include
+  ${INCLUDE_DIR}
+)
+
+link_directories(${LIB_DIR})
+
+set(dali_csharp_binder_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../dali-csharp-binder)
+
+set(SOURCES
+  ${dali_csharp_binder_dir}/src/callbackbase_wrap.cpp
+  ${dali_csharp_binder_dir}/src/keyboard_focus_manager_wrap.cpp
+  ${dali_csharp_binder_dir}/src/devel-property-wrap.cpp
+  ${dali_csharp_binder_dir}/src/version-check.cpp
+  ${dali_csharp_binder_dir}/src/layout-controller.cpp
+  ${dali_csharp_binder_dir}/src/flex-layout.cpp
+  ${dali_csharp_binder_dir}/src/gestures.cpp
+  ${dali_csharp_binder_dir}/src/view-wrapper-impl-wrap.cpp
+  ${dali_csharp_binder_dir}/src/event-thread-callback-wrap.cpp
+  ${dali_csharp_binder_dir}/src/application.cpp
+  ${dali_csharp_binder_dir}/src/text-editor.cpp
+  ${dali_csharp_binder_dir}/src/text-field.cpp
+  ${dali_csharp_binder_dir}/src/window.cpp
+  ${dali_csharp_binder_dir}/src/tts-player.cpp
+  ${dali_csharp_binder_dir}/src/input-method-context.cpp
+  ${dali_csharp_binder_dir}/src/input-method-options.cpp
+  ${dali_csharp_binder_dir}/src/animation.cpp
+  ${dali_csharp_binder_dir}/src/adaptor.cpp
+  ${dali_csharp_binder_dir}/src/extents.cpp
+  ${dali_csharp_binder_dir}/src/text-label.cpp
+  ${dali_csharp_binder_dir}/src/text-utils.cpp
+  ${dali_csharp_binder_dir}/src/dali_wrap.cpp
+)
+
+add_library(${name} SHARED ${SOURCES})
+target_link_libraries(${name} ${REQUIRED_LIBS})
+
+set_target_properties(${name}
+  PROPERTIES
+  VERSION ${${name}_VERSION}
+  SOVERSION ${${name}_VERSION_MAJOR}
+  CLEAN_DIRECT_OUPUT 1
+)
+
+# Install the pdb file.
+if( ${CMAKE_BUILD_TYPE} MATCHES Debug )
+  set(BIN_DIR ${BIN_DIR}/debug)
+  set(LIB_DIR ${LIB_DIR}/debug)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Debug/${name}.pdb DESTINATION ${BIN_DIR} )
+endif()
+
+# Install the library so file and symlinks
+install( TARGETS ${name}
+  LIBRARY DESTINATION ${LIB_DIR}
+  ARCHIVE DESTINATION ${LIB_DIR}
+  RUNTIME DESTINATION ${BIN_DIR}
+)

--- a/dali-csharp-binder/src/application.cpp
+++ b/dali-csharp-binder/src/application.cpp
@@ -726,9 +726,9 @@ SWIGEXPORT unsigned int SWIGSTDCALL CSharp_Dali_Application_GetWindowsListSize()
   return jresult;
 }
 
-SWIGEXPORT void * SWIGSTDCALL CSharp_Dali_Application_GetWindowsFromList(uint jarg1) {
+SWIGEXPORT void * SWIGSTDCALL CSharp_Dali_Application_GetWindowsFromList(unsigned int jarg1) {
   void * jresult ;
-  uint index = jarg1;
+  unsigned int index = jarg1;
   Dali::WindowContainer result;
 
   {

--- a/dali-csharp-binder/src/dali_wrap.cpp
+++ b/dali-csharp-binder/src/dali_wrap.cpp
@@ -419,6 +419,7 @@ void SWIG_CSharpException(int code, const char *msg) {
 
 #define SWIGSTDCALL
 
+#include <time.h>
 
 #include <dali/dali.h>
 #include <dali-toolkit/dali-toolkit.h>

--- a/dali-csharp-binder/src/text-utils.cpp
+++ b/dali-csharp-binder/src/text-utils.cpp
@@ -22,11 +22,11 @@
 #include <dali/dali.h>
 #include <dali-toolkit/devel-api/text/text-utils-devel.h>
 
+extern SWIG_CSharpStringHelperCallback SWIG_csharp_string_callback;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-extern SWIG_CSharpStringHelperCallback SWIG_csharp_string_callback;
 
 SWIGEXPORT void * SWIGSTDCALL CSharp_Dali_new_RendererParameters_0() {
   void * jresult ;


### PR DESCRIPTION
Under build/tizen there is a CMakeLists.txt file that provides builds
for the Windows platform. The README file was updated with instructions
to build it.

We also fix small build issues when compiling with msvc.